### PR TITLE
fixes goat-io/fluent#165

### DIFF
--- a/packages/dev/Database/Firebase/Dockerfile
+++ b/packages/dev/Database/Firebase/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM python:3.8-slim-buster
 ################################################################################
 # Original Source
 # https://github.com/eHealthAfrica/firebase-emulator/blob/master/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get install -y nodejs
 RUN sudo npm install -g firebase-tools
 
 # Install gcloud commmand utilities to use default login
-RUN curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=/root/gcloud --disable-prompts
+RUN curl -sSL https://sdk.cloud.google.com > /tmp/gcl && sudo bash /tmp/gcl --install-dir=/root/gcloud --disable-prompts
 
 ENV PATH $PATH:~/gcloud/google-cloud-sdk/bin
 


### PR DESCRIPTION
This PR fixes a Docker Build issue for the firebase-emulator Docker Image found in `packages/dev/Database/Firebase`.

Two issues have been identified: 
1. The install script from Google Cloud SDK in the build step 15 now required python 3.8 instead of previously 3.7
2. The Google Cloud SDK script needs to run with elevated privileges inside the Docker Image as otherwise it is not available to run `mkdir /root`