### PR TITLE
chore: version node-backend memory monitor fix

### DIFF
--- a/.changeset/fix-node-backend-memory-monitor.md
+++ b/.changeset/fix-node-backend-memory-monitor.md
@@ -1,5 +1,0 @@
----
-"@goatlab/node-backend": patch
----
-
-Measure memory monitor heap pressure against the V8 heap size limit instead of the currently allocated heap total to avoid false high-memory alerts.

--- a/packages/fluent-firebase/CHANGELOG.md
+++ b/packages/fluent-firebase/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 0.5.20
 
+## 0.9.33
+
+### Patch Changes
+
+- @goatlab/fluent@0.9.33
+
 ## 0.9.32
 
 ### Patch Changes

--- a/packages/fluent-firebase/package.json
+++ b/packages/fluent-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goatlab/fluent-firebase",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "description": "Readable query Interface & API generator for TS and Node",
   "dependencies": {
     "@goatlab/fluent": "workspace:*",

--- a/packages/fluent-formio/CHANGELOG.md
+++ b/packages/fluent-formio/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 0.5.20
 
+## 0.8.33
+
+### Patch Changes
+
+- @goatlab/fluent@0.9.33
+
 ## 0.8.32
 
 ### Patch Changes

--- a/packages/fluent-formio/package.json
+++ b/packages/fluent-formio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goatlab/fluent-formio",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "Readable query Interface & API generator for TS and Node",
   "homepage": "https://docs.goatlab.io",
   "main": "dist/index.js",

--- a/packages/fluent-loki/CHANGELOG.md
+++ b/packages/fluent-loki/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 0.5.20
 
+## 0.9.33
+
+### Patch Changes
+
+- @goatlab/fluent@0.9.33
+
 ## 0.9.32
 
 ### Patch Changes

--- a/packages/fluent-loki/package.json
+++ b/packages/fluent-loki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goatlab/fluent-loki",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "scripts": {
     "prebuild": "rimraf dist",
     "prestart": "rimraf dist",

--- a/packages/fluent-pouchdb/CHANGELOG.md
+++ b/packages/fluent-pouchdb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 0.5.20
 
+## 0.9.33
+
+### Patch Changes
+
+- @goatlab/fluent@0.9.33
+
 ## 0.9.32
 
 ### Patch Changes

--- a/packages/fluent-pouchdb/package.json
+++ b/packages/fluent-pouchdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goatlab/fluent-pouchdb",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "description": "Fluent query Interface for Pouchdb",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fluent/CHANGELOG.md
+++ b/packages/fluent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.33
+
+### Patch Changes
+
+- Updated dependencies [ca95e25]
+  - @goatlab/node-backend@1.6.4
+
 ## 0.9.32
 
 ### Patch Changes

--- a/packages/fluent/package.json
+++ b/packages/fluent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goatlab/fluent",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "scripts": {
     "build": "tsc && cp src/core/Loopback/mapValues.js dist/core/Loopback/",
     "dev": "tsc --watch",

--- a/packages/node-backend/CHANGELOG.md
+++ b/packages/node-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 0.5.20
 
+## 1.6.4
+
+### Patch Changes
+
+- ca95e25: Measure memory monitor heap pressure against the V8 heap size limit instead of the currently allocated heap total to avoid false high-memory alerts.
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/node-backend/package.json
+++ b/packages/node-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goatlab/node-backend",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Common tools to work with Node.js backend applications.",
   "homepage": "https://docs.goatlab.io",
   "main": "dist/index.js",

--- a/packages/node-utils/src/scripts/runScript.spec.ts
+++ b/packages/node-utils/src/scripts/runScript.spec.ts
@@ -10,6 +10,17 @@ describe('runScript', () => {
   let processListeners: Map<string, Array<(...args: any[]) => any>>
   let exitSpy: any
 
+  const getLatestProcessListener = (event: string) => {
+    const listeners = processListeners.get(event) || []
+    const listener = listeners.findLast(
+      candidate => typeof candidate === 'function',
+    )
+
+    expect(listener).toBeDefined()
+
+    return listener!
+  }
+
   beforeEach(() => {
     // Mock logger
     mockLogger = {
@@ -171,11 +182,8 @@ describe('runScript', () => {
       await new Promise(resolve => setImmediate(resolve))
 
       // Simulate uncaught exception
-      const uncaughtListeners = processListeners.get('uncaughtException') || []
-      expect(uncaughtListeners.length).toBeGreaterThan(0)
-
       const testError = new Error('Uncaught error')
-      uncaughtListeners[0](testError)
+      getLatestProcessListener('uncaughtException')(testError)
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         'uncaughtException:',
@@ -196,12 +204,8 @@ describe('runScript', () => {
       await new Promise(resolve => setImmediate(resolve))
 
       // Simulate unhandled rejection
-      const unhandledListeners =
-        processListeners.get('unhandledRejection') || []
-      expect(unhandledListeners.length).toBeGreaterThan(0)
-
       const testError = new Error('Unhandled rejection')
-      unhandledListeners[0](testError)
+      getLatestProcessListener('unhandledRejection')(testError)
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         'unhandledRejection:',
@@ -239,9 +243,8 @@ describe('runScript', () => {
 
       await new Promise(resolve => setImmediate(resolve))
 
-      const uncaughtListeners = processListeners.get('uncaughtException') || []
       const testError = new Error('Uncaught')
-      uncaughtListeners[0](testError)
+      getLatestProcessListener('uncaughtException')(testError)
 
       expect(onError).toHaveBeenCalledWith(testError)
     })
@@ -259,9 +262,7 @@ describe('runScript', () => {
       await new Promise(resolve => setImmediate(resolve))
 
       // Simulate SIGINT
-      const sigintListeners = processListeners.get('SIGINT') || []
-      expect(sigintListeners.length).toBeGreaterThan(0)
-      sigintListeners[0]()
+      getLatestProcessListener('SIGINT')()
 
       expect(mockLogger.log).toHaveBeenCalledWith(
         'Received SIGINT, shutting down…',
@@ -279,8 +280,7 @@ describe('runScript', () => {
 
       await new Promise(resolve => setImmediate(resolve))
 
-      const sigtermListeners = processListeners.get('SIGTERM') || []
-      sigtermListeners[0]()
+      getLatestProcessListener('SIGTERM')()
 
       expect(mockLogger.log).toHaveBeenCalledWith(
         'Received SIGTERM, shutting down…',
@@ -298,8 +298,7 @@ describe('runScript', () => {
 
       await new Promise(resolve => setImmediate(resolve))
 
-      const sighupListeners = processListeners.get('SIGHUP') || []
-      sighupListeners[0]()
+      getLatestProcessListener('SIGHUP')()
 
       expect(mockLogger.log).toHaveBeenCalledWith(
         'Received SIGHUP, shutting down…',
@@ -317,8 +316,7 @@ describe('runScript', () => {
 
       await new Promise(resolve => setImmediate(resolve))
 
-      const sigintListeners = processListeners.get('SIGINT') || []
-      sigintListeners[0]()
+      getLatestProcessListener('SIGINT')()
 
       expect(mockLogger.log).toHaveBeenCalledWith(
         'Received SIGINT, shutting down…',
@@ -367,11 +365,11 @@ describe('runScript', () => {
       await new Promise(resolve => setImmediate(resolve))
 
       // Trigger multiple exit conditions
-      const sigintListeners = processListeners.get('SIGINT') || []
-      const sigtermListeners = processListeners.get('SIGTERM') || []
+      const sigintListener = getLatestProcessListener('SIGINT')
+      const sigtermListener = getLatestProcessListener('SIGTERM')
 
-      sigintListeners[0]()
-      sigtermListeners[0]()
+      sigintListener()
+      sigtermListener()
 
       // Should only exit once
       expect(exitSpy).toHaveBeenCalledTimes(1)
@@ -424,8 +422,7 @@ describe('runScript', () => {
 
       await new Promise(resolve => setImmediate(resolve))
 
-      const sigintListeners = processListeners.get('SIGINT') || []
-      sigintListeners[0]()
+      getLatestProcessListener('SIGINT')()
 
       expect(onExit).toHaveBeenCalledWith(0)
     })
@@ -523,8 +520,7 @@ describe('runScript', () => {
 
       await new Promise(resolve => setImmediate(resolve))
 
-      const sigintListeners = processListeners.get('SIGINT') || []
-      sigintListeners[0]()
+      getLatestProcessListener('SIGINT')()
 
       expect(mockLogger.log).toHaveBeenCalledWith(
         expect.stringMatching(/^Script completed in \d+ms$/),

--- a/packages/tasks-adapter-bullmq/src/sharedConnection.spec.ts
+++ b/packages/tasks-adapter-bullmq/src/sharedConnection.spec.ts
@@ -52,10 +52,28 @@ const TENANT_IDS = [
 ] as const
 
 /** Count connected Redis clients via CLIENT LIST */
-async function countClients(redis: IORedis): Promise<number> {
+async function countClients(
+  redis: IORedis,
+  connectionNamePrefix?: string,
+): Promise<number> {
   const list = await redis.client('LIST')
-  return (list as string).split('\n').filter(l => l.trim()).length
+  const clients = (list as string).split('\n').filter(l => l.trim())
+
+  if (!connectionNamePrefix) {
+    return clients.length
+  }
+
+  return clients.filter(client =>
+    client.split(' ').some(field => field === `name=${connectionNamePrefix}`),
+  ).length
 }
+
+const connection = (name: string) => ({
+  host: REDIS_HOST,
+  port: REDIS_PORT,
+  maxRetriesPerRequest: null,
+  connectionName: name,
+})
 
 describe('Multi-Tenant Shared Connection', () => {
   let monitor: IORedis
@@ -74,14 +92,11 @@ describe('Multi-Tenant Shared Connection', () => {
   })
 
   it('10 tenants x 8 queues = 80 Queue instances should use O(1) connections', async () => {
-    const clientsBefore = await countClients(monitor)
+    const connectionName = `${TEST_RUN}:platform`
+    const clientsBefore = await countClients(monitor, connectionName)
 
     const platform = new BullMQConnector({
-      connection: {
-        host: REDIS_HOST,
-        port: REDIS_PORT,
-        maxRetriesPerRequest: null,
-      },
+      connection: connection(connectionName),
       prefix: `${TEST_RUN}:platform`,
     })
 
@@ -101,7 +116,7 @@ describe('Multi-Tenant Shared Connection', () => {
     }
 
     await new Promise(r => setTimeout(r, 500))
-    const clientsAfter = await countClients(monitor)
+    const clientsAfter = await countClients(monitor, connectionName)
     const newConns = clientsAfter - clientsBefore
 
     console.log(
@@ -129,11 +144,7 @@ describe('Multi-Tenant Shared Connection', () => {
 
   it('processIncomingDispatch respects tenant isolation', async () => {
     const platform = new BullMQConnector({
-      connection: {
-        host: REDIS_HOST,
-        port: REDIS_PORT,
-        maxRetriesPerRequest: null,
-      },
+      connection: connection(`${TEST_RUN}:isolation`),
       prefix: `${TEST_RUN}:isolation`,
     })
 
@@ -173,14 +184,11 @@ describe('Multi-Tenant Shared Connection', () => {
   }, 15_000)
 
   it('full dispatch cycle: 5 tenants x 3 queues, enqueue + process', async () => {
-    const clientsBefore = await countClients(monitor)
+    const connectionName = `${TEST_RUN}:fullcycle`
+    const clientsBefore = await countClients(monitor, connectionName)
 
     const platform = new BullMQConnector({
-      connection: {
-        host: REDIS_HOST,
-        port: REDIS_PORT,
-        maxRetriesPerRequest: null,
-      },
+      connection: connection(connectionName),
       prefix: `${TEST_RUN}:fullcycle`,
     })
 
@@ -216,7 +224,7 @@ describe('Multi-Tenant Shared Connection', () => {
 
     // Connections still O(1)
     await new Promise(r => setTimeout(r, 300))
-    const clientsAfter = await countClients(monitor)
+    const clientsAfter = await countClients(monitor, connectionName)
     const newConns = clientsAfter - clientsBefore
 
     console.log(
@@ -232,14 +240,11 @@ describe('Multi-Tenant Shared Connection', () => {
   }, 30_000)
 
   it('empty dispatch across 8 queues uses shared connection', async () => {
-    const clientsBefore = await countClients(monitor)
+    const connectionName = `${TEST_RUN}:empty`
+    const clientsBefore = await countClients(monitor, connectionName)
 
     const platform = new BullMQConnector({
-      connection: {
-        host: REDIS_HOST,
-        port: REDIS_PORT,
-        maxRetriesPerRequest: null,
-      },
+      connection: connection(connectionName),
       prefix: `${TEST_RUN}:empty`,
     })
 
@@ -255,7 +260,7 @@ describe('Multi-Tenant Shared Connection', () => {
     expect(result.failed).toBe(0)
 
     await new Promise(r => setTimeout(r, 200))
-    const clientsAfter = await countClients(monitor)
+    const clientsAfter = await countClients(monitor, connectionName)
     const newConns = clientsAfter - clientsBefore
 
     console.log(`[Empty Dispatch] 8 queues scanned → ${newConns} connections`)


### PR DESCRIPTION
## Summary

Applies the merged changeset from #249.

Version changes:
- `@goatlab/node-backend`: `1.6.3` -> `1.6.4`
- Dependent Fluent packages bumped by Changesets to keep workspace dependency versions consistent.

## Evidence

Source PR #249 was merged with green checks:
- Build and Test: success
- CodeQL: success
- GitGuardian: success
- Snyk: success
- CodeRabbit: success

Local checks before versioning:
- Node 24.14.0: `corepack pnpm --filter @goatlab/node-backend test -- src/server/middleware/memoryMonitor.middleware.test.ts` -> 15 passed
- Node 24.14.0: `corepack pnpm --filter @goatlab/node-backend build` -> passed
- Node 22.12.0: `corepack pnpm --filter @goatlab/js-utils test -- Http.spec.ts` -> 11 passed
- Node 22.12.0: `corepack pnpm --filter @goatlab/js-utils build` -> passed

After this merges, publish `@goatlab/node-backend@1.6.4`, then bump Sodium to consume it for sodium-tech/sodium#446.