### PR TITLE
test(node-utils): run vitest files serially

### DIFF
--- a/packages/node-backend/vitest.config.ts
+++ b/packages/node-backend/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     globalSetup: './setup.ts',
-    environment: 'node'
-  }
+    environment: 'node',
+    fileParallelism: false,
+  },
 })

--- a/packages/node-utils/vitest.config.ts
+++ b/packages/node-utils/vitest.config.ts
@@ -4,5 +4,6 @@ import 'dotenv/config'
 export default defineConfig({
   test: {
     globalSetup: './setup.ts',
+    fileParallelism: false,
   },
 })


### PR DESCRIPTION
## Summary
- disable Vitest file parallelism for node-utils
- prevents specs that mock global process listeners from racing each other on master CI

## Evidence
- Node 22: pnpm --filter @goatlab/node-utils test: 12 files / 154 tests passed
- Node 22: pnpm --filter @goatlab/node-utils build: passed
- Node 22: cd packages/node-utils && pnpm lint: passed