### PR TITLE
fix(tasks-adapter-bullmq): dispatch locks must outlive the time budget; decouple concurrency from batchSize

### DIFF
--- a/packages/tasks-adapter-bullmq/package.json
+++ b/packages/tasks-adapter-bullmq/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@goatlab/tasks-adapter-bullmq",
-	"version": "0.10.3",
+	"version": "0.10.4",
 	"description": "BullMQ Tasks adapter for Goatlab tasks",
 	"homepage": "https://docs.goatlab.io",
 	"main": "dist/index.js",

--- a/packages/tasks-adapter-bullmq/src/BullMQConnector.ts
+++ b/packages/tasks-adapter-bullmq/src/BullMQConnector.ts
@@ -798,9 +798,15 @@ export class BullMQConnector implements TaskConnector<object> {
   }): Promise<{ processed: number; failed: number }> {
     const { handleTask, timeBudgetMs = 25_000, validQueueNames, hint } = params
     const batchSize = Math.max(1, params.batchSize ?? 50)
+    // Default concurrency is deliberately DECOUPLED from batchSize: handlers
+    // run in the caller's process (usually the API server). With the old
+    // `?? batchSize` default, a hint flood meant N concurrent dispatch calls
+    // x 50 concurrent handlers EACH on one Node event loop — starving every
+    // in-flight HTTP request (sodium prod p99 incident, 2026-07-09). Pull
+    // wide (batchSize), execute narrow (concurrency).
     const concurrency = Math.max(
       1,
-      Math.min(params.concurrency ?? batchSize, batchSize),
+      Math.min(params.concurrency ?? 10, batchSize),
     )
     const deadline = Date.now() + timeBudgetMs
     let processed = 0
@@ -831,6 +837,15 @@ export class BullMQConnector implements TaskConnector<object> {
         connection: this.getSharedConnection(),
         prefix: this._prefix,
         autorun: false,
+        // Locks acquired via manual getNextJob are NEVER renewed (renewal is
+        // the processing loop's job, and there is none in autorun:false mode).
+        // With BullMQ's default 30s lockDuration, any handler slower than 30s
+        // -- or whose ack is delayed by event-loop pressure -- loses its lock:
+        // moveToCompleted throws, the job strands in `active` until an
+        // external reaper deletes it, and the workflow watchdog re-enqueues
+        // it (duplicate execution; sodium prod OTP-email delays, 2026-07-09).
+        // The lock must outlive the whole dispatch cycle.
+        lockDuration: timeBudgetMs + 60_000,
       })
 
       try {


### PR DESCRIPTION
Root-cause fix for the sodium prod p99/OTP-delay incident (2026-07-09). See commit message for the self-amplifying loop mechanics. v0.10.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dispatch handling to better control how many jobs run at once, reducing overload during bursts of incoming work.
  * Increased job processing lock timing so tasks are less likely to expire mid-run, helping prevent duplicate processing or stuck jobs.
* **Chores**
  * Bumped the package version to `0.10.4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->